### PR TITLE
Feat: Prefer basic parts first in results

### DIFF
--- a/test-basic.ts
+++ b/test-basic.ts
@@ -1,0 +1,15 @@
+import { jlcPartsEngine } from "./lib/jlc-parts-engine"
+
+const run = async () => {
+  const result = await jlcPartsEngine.findPart({
+    sourceComponent: {
+      type: "source_component",
+      ftype: "simple_resistor",
+      resistance: "10k",
+    },
+    footprinterString: "0603",
+  })
+  console.log(result)
+}
+
+run()


### PR DESCRIPTION
/claim #781, related to bounty task (https://github.com/tscircuit/tscircuit/issues/781). I added a sorting logic to prefer basic (`isBasic: true`) parts at the top of the returned `jlcpcb` array. The non-basic parts retain their original order relative to each other. It also works in accordance with the updated `isBasic` detection in jlcsearch.
