### PR TITLE
feat: Support KiCad footprints for JLC part sourcing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+.aider*

--- a/lib/footprint-translators/get-footprinter-string-from-kicad.ts
+++ b/lib/footprint-translators/get-footprinter-string-from-kicad.ts
@@ -1,0 +1,21 @@
+/**
+ * Transforms a KiCad footprint string into a generic "footprinter string".
+ * For now, this is a simplified conversion to a standard package name.
+ * e.g. "kicad:Resistor_SMD:R_0603_1608Metric" -> "0603"
+ */
+export const getFootprinterStringFromKicad = (
+  kicadFootprint: string,
+): string | undefined => {
+  // kicad:Resistor_SMD:R_0603_1608Metric -> 0603
+  let match = kicadFootprint.match(/:[RC]_(\d{4})_/)
+  if (match) return match[1]
+
+  // kicad:Package_SO:SOIC-8_3.9x4.9mm_P1.27mm -> SOIC-8
+  // kicad:Package_TO_SOT_SMD:SOT-23 -> SOT-23
+  match = kicadFootprint.match(
+    /:(SOIC-\d+|SOT-\d+|SOD-\d+|SSOP-\d+|TSSOP-\d+|QFP-\d+|QFN-\d+)/,
+  )
+  if (match) return match[1]
+
+  return undefined
+}

--- a/lib/footprint-translators/get-jlc-package-from-footprinter-string.ts
+++ b/lib/footprint-translators/get-jlc-package-from-footprinter-string.ts
@@ -1,0 +1,12 @@
+/**
+ * Transforms a generic "footprinter string" into a JLC-compatible package name.
+ * e.g. "0603cap" -> "0603"
+ */
+export const getJlcPackageFromFootprinterString = (
+  footprinterString: string,
+): string => {
+  if (footprinterString.includes("cap")) {
+    return footprinterString.replace("cap", "")
+  }
+  return footprinterString
+}

--- a/lib/footprint-translators/get-jlc-package-from-footprinter-string.ts
+++ b/lib/footprint-translators/get-jlc-package-from-footprinter-string.ts
@@ -1,12 +1,12 @@
 /**
  * Transforms a generic "footprinter string" into a JLC-compatible package name.
- * e.g. "0603cap" -> "0603"
+ * e.g. "cap0603" -> "0603"
  */
 export const getJlcPackageFromFootprinterString = (
   footprinterString: string,
 ): string => {
   if (footprinterString.includes("cap")) {
-    return footprinterString.replace("cap", "")
+    return footprinterString.replace(/cap/g, "")
   }
   return footprinterString
 }

--- a/lib/footprint-translators/index.ts
+++ b/lib/footprint-translators/index.ts
@@ -1,0 +1,25 @@
+import { getFootprinterStringFromKicad } from "./get-footprinter-string-from-kicad"
+import { getJlcPackageFromFootprinterString } from "./get-jlc-package-from-footprinter-string"
+
+/**
+ * Get a JLC-compatible package name from a footprint string, which could be
+ * a KiCad footprint or a generic "footprinter string".
+ */
+export const getApiPackageName = (
+  footprint: string | undefined,
+): string | undefined => {
+  if (!footprint) return undefined
+
+  if (footprint.startsWith("kicad:")) {
+    const footprinterString = getFootprinterStringFromKicad(footprint)
+    if (footprinterString) {
+      return getJlcPackageFromFootprinterString(footprinterString)
+    }
+
+    // Fallback for un-matched KiCad strings
+    return footprint
+  }
+
+  // Not a KiCad string, assume it's a footprinter string
+  return getJlcPackageFromFootprinterString(footprint)
+}

--- a/lib/footprint-translators/index.ts
+++ b/lib/footprint-translators/index.ts
@@ -5,7 +5,7 @@ import { getJlcPackageFromFootprinterString } from "./get-jlc-package-from-footp
  * Get a JLC-compatible package name from a footprint string, which could be
  * a KiCad footprint or a generic "footprinter string".
  */
-export const getApiPackageName = (
+export const getJlcpcbPackageName = (
   footprint: string | undefined,
 ): string | undefined => {
   if (!footprint) return undefined

--- a/lib/jlc-parts-engine.ts
+++ b/lib/jlc-parts-engine.ts
@@ -1,5 +1,5 @@
 import type { PartsEngine, SupplierPartNumbers } from "@tscircuit/props"
-import { getApiPackageName } from "./footprint-translators/index"
+import { getJlcpcbPackageName } from "./footprint-translators/index"
 
 const cache = new Map<string, any>()
 
@@ -24,7 +24,7 @@ export const jlcPartsEngine: PartsEngine = {
     sourceComponent,
     footprinterString,
   }): Promise<SupplierPartNumbers> => {
-    const packageForApi = getApiPackageName(footprinterString)
+    const jlcpcbPackage = getJlcpcbPackageName(footprinterString)
 
     if (
       sourceComponent.type === "source_component" &&
@@ -32,7 +32,7 @@ export const jlcPartsEngine: PartsEngine = {
     ) {
       const { resistors } = await getJlcPartsCached("resistors", {
         resistance: sourceComponent.resistance,
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
 
       return {
@@ -44,7 +44,7 @@ export const jlcPartsEngine: PartsEngine = {
     ) {
       const { capacitors } = await getJlcPartsCached("capacitors", {
         capacitance: sourceComponent.capacitance,
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
 
       return {
@@ -80,7 +80,7 @@ export const jlcPartsEngine: PartsEngine = {
     ) {
       const { potentiometers } = await getJlcPartsCached("potentiometers", {
         resistance: sourceComponent.max_resistance,
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
       return {
         jlcpcb: (potentiometers ?? [])
@@ -92,7 +92,7 @@ export const jlcPartsEngine: PartsEngine = {
       sourceComponent.ftype === "simple_diode"
     ) {
       const { diodes } = await getJlcPartsCached("diodes", {
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
       return {
         jlcpcb: (diodes ?? []).map((d: any) => `C${d.lcsc}`).slice(0, 3),
@@ -102,7 +102,7 @@ export const jlcPartsEngine: PartsEngine = {
       sourceComponent.ftype === "simple_chip"
     ) {
       const { chips } = await getJlcPartsCached("chips", {
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
       return {
         jlcpcb: (chips ?? []).map((c: any) => `C${c.lcsc}`).slice(0, 3),
@@ -112,7 +112,7 @@ export const jlcPartsEngine: PartsEngine = {
       sourceComponent.ftype === "simple_transistor"
     ) {
       const { transistors } = await getJlcPartsCached("transistors", {
-        package: packageForApi,
+        package: jlcpcbPackage,
         transistor_type: sourceComponent.transistor_type,
       })
       return {
@@ -124,7 +124,7 @@ export const jlcPartsEngine: PartsEngine = {
     ) {
       const { power_sources } = await getJlcPartsCached("power_sources", {
         voltage: sourceComponent.voltage,
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
       return {
         jlcpcb: (power_sources ?? []).map((p: any) => `C${p.lcsc}`).slice(0, 3),
@@ -135,7 +135,7 @@ export const jlcPartsEngine: PartsEngine = {
     ) {
       const { inductors } = await getJlcPartsCached("inductors", {
         inductance: sourceComponent.inductance,
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
       return {
         jlcpcb: (inductors ?? []).map((i: any) => `C${i.lcsc}`).slice(0, 3),
@@ -147,7 +147,7 @@ export const jlcPartsEngine: PartsEngine = {
       const { crystals } = await getJlcPartsCached("crystals", {
         frequency: sourceComponent.frequency,
         load_capacitance: sourceComponent.load_capacitance,
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
       return {
         jlcpcb: (crystals ?? []).map((c: any) => `C${c.lcsc}`).slice(0, 3),
@@ -157,7 +157,7 @@ export const jlcPartsEngine: PartsEngine = {
       sourceComponent.ftype === "simple_mosfet"
     ) {
       const { mosfets } = await getJlcPartsCached("mosfets", {
-        package: packageForApi,
+        package: jlcpcbPackage,
         mosfet_mode: sourceComponent.mosfet_mode,
         channel_type: sourceComponent.channel_type,
       })
@@ -170,7 +170,7 @@ export const jlcPartsEngine: PartsEngine = {
     ) {
       const { resonators } = await getJlcPartsCached("resonators", {
         frequency: sourceComponent.frequency,
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
       return {
         jlcpcb: (resonators ?? []).map((r: any) => `C${r.lcsc}`).slice(0, 3),
@@ -181,7 +181,7 @@ export const jlcPartsEngine: PartsEngine = {
     ) {
       const { switches } = await getJlcPartsCached("switches", {
         switch_type: sourceComponent.type,
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
       return {
         jlcpcb: (switches ?? []).map((s: any) => `C${s.lcsc}`).slice(0, 3),
@@ -191,7 +191,7 @@ export const jlcPartsEngine: PartsEngine = {
       sourceComponent.ftype === "simple_led"
     ) {
       const { leds } = await getJlcPartsCached("leds", {
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
       return {
         jlcpcb: (leds ?? []).map((l: any) => `C${l.lcsc}`).slice(0, 3),
@@ -201,7 +201,7 @@ export const jlcPartsEngine: PartsEngine = {
       sourceComponent.ftype === "simple_fuse"
     ) {
       const { fuses } = await getJlcPartsCached("fuses", {
-        package: packageForApi,
+        package: jlcpcbPackage,
       })
       return {
         jlcpcb: (fuses ?? []).map((l: any) => `C${l.lcsc}`).slice(0, 3),

--- a/tests/jlc-parts-engine.test.ts
+++ b/tests/jlc-parts-engine.test.ts
@@ -157,7 +157,7 @@ describe("jlcPartsEngine", () => {
 
     const result = await jlcPartsEngine.findPart({
       sourceComponent: capacitor,
-      footprinterString: "0603cap",
+      footprinterString: "cap0603",
     })
 
     expect(result).toEqual({

--- a/tests/jlc-parts-engine.test.ts
+++ b/tests/jlc-parts-engine.test.ts
@@ -127,6 +127,25 @@ describe("jlcPartsEngine", () => {
     })
   })
 
+  test("should find resistor parts with kicad footprint", async () => {
+    const resistor: AnySourceComponent = {
+      type: "source_component",
+      ftype: "simple_resistor",
+      resistance: 10000,
+      source_component_id: "source_component_0",
+      name: "R1",
+    }
+
+    const result = await jlcPartsEngine.findPart({
+      sourceComponent: resistor,
+      footprinterString: "kicad:Resistor_SMD:R_0603_1608Metric",
+    })
+
+    expect(result).toEqual({
+      jlcpcb: ["C1234", "C5678", "C9012"],
+    })
+  })
+
   test("should find capacitor parts", async () => {
     const capacitor: AnySourceComponent = {
       type: "source_component",
@@ -215,6 +234,24 @@ describe("jlcPartsEngine", () => {
     const result = await jlcPartsEngine.findPart({
       sourceComponent: chip,
       footprinterString: "SOIC-8",
+    })
+
+    expect(result).toEqual({
+      jlcpcb: ["C5678", "C9012", "C3456"],
+    })
+  })
+
+  test("should find chip parts with kicad footprint", async () => {
+    const chip: AnySourceComponent = {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+    }
+
+    const result = await jlcPartsEngine.findPart({
+      sourceComponent: chip,
+      footprinterString: "kicad:Package_SO:SOIC-8_3.9x4.9mm_P1.27mm",
     })
 
     expect(result).toEqual({


### PR DESCRIPTION
This pull request adds support for sourcing JLC parts using KiCad footprint strings (kicad:*).                                                          

A helper function has been added to parse common KiCad footprint formats (e.g., kicad:Resistor_SMD:R_0603_1608Metric) into standard package names (e.g., 0603)
that can be used with the JLCPCB search API. The parts engine now uses this function to find parts for components with KiCad footprints.

/claim [#782](https://github.com/tscircuit/tscircuit/issues/782)
/closes [#782](https://github.com/tscircuit/tscircuit/issues/782)