### PR TITLE
fix: report invalid EasyEDA payloads

### DIFF
--- a/lib/jlc-parts-engine/JlcPartsEngine.ts
+++ b/lib/jlc-parts-engine/JlcPartsEngine.ts
@@ -1,8 +1,8 @@
 import type { PartsEngine } from "@tscircuit/props"
 import {
-  fetchEasyEDAComponent,
   EasyEdaJsonSchema,
   convertEasyEdaJsonToCircuitJson,
+  fetchEasyEDAComponent,
 } from "easyeda/browser"
 import { getJlcpcbPackageName } from "../footprint-translators/index"
 import { getFetchWithEasyEdaProxy } from "./getFetchWithEasyEdaProxy"
@@ -301,7 +301,22 @@ export class JlcPcbPartsEngine implements PartsEngine {
         fetch: easyEdaPlatformFetch as typeof fetch,
       },
     )
-    const parsed = EasyEdaJsonSchema.parse(rawEasyEdaJson)
+    const parsedResult = EasyEdaJsonSchema.safeParse(rawEasyEdaJson)
+    if (!parsedResult.success) {
+      const issueSummary = parsedResult.error.issues
+        .slice(0, 3)
+        .map((issue) => {
+          const path = issue.path.length > 0 ? issue.path.join(".") : "<root>"
+          return `${path}: ${issue.message}`
+        })
+        .join("; ")
+
+      throw new Error(
+        `Invalid EasyEDA payload for ${resolvedSupplierPartNumber}: ${issueSummary}`,
+      )
+    }
+
+    const parsed = parsedResult.data
     return convertEasyEdaJsonToCircuitJson(parsed)
   }
 }

--- a/tests/easyeda-proxy.test.ts
+++ b/tests/easyeda-proxy.test.ts
@@ -128,3 +128,50 @@ test("JlcPcbPartsEngine applies EasyEDA proxy to fetchPartCircuitJson", async ()
     await fakeProxyServer.stop()
   }
 })
+
+test("fetchPartCircuitJson reports invalid EasyEDA payloads with part context", async () => {
+  const engine = new JlcPcbPartsEngine({
+    platformFetch: (async (url: string) => {
+      if (url.includes("/api/components/search")) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            result: {
+              lists: {
+                lcsc: [
+                  {
+                    uuid: "bad-component-uuid",
+                    dataStr: {
+                      head: {
+                        c_para: {
+                          "Supplier Part": "C123",
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+          { status: 200 },
+        )
+      }
+
+      return new Response(
+        JSON.stringify({
+          result: {
+            uuid: "bad-component-uuid",
+            lcsc: { number: "C123" },
+          },
+        }),
+        { status: 200 },
+      )
+    }) as unknown as typeof fetch,
+  })
+
+  await expect(
+    engine.fetchPartCircuitJson!({
+      supplierPartNumber: "C123",
+    }),
+  ).rejects.toThrow("Invalid EasyEDA payload for C123")
+})


### PR DESCRIPTION
Fixes #15

@algora-pbc /claim #15

## Summary
- Validate EasyEDA detail payloads with `safeParse` before converting to Circuit JSON.
- Include the supplier part number and schema issue summary when an invalid payload is returned.
- Add a regression test for malformed EasyEDA responses fetched through `fetchPartCircuitJson`.

## Verification
- `bun test tests\easyeda-proxy.test.ts`
- `bun x biome check tests\easyeda-proxy.test.ts`
- `bun x tsc --noEmit`
- `git diff --check`