### PR TITLE
Don't send switch_type=source_component on switch searches

### DIFF
--- a/lib/jlc-parts-engine/JlcPartsEngine.ts
+++ b/lib/jlc-parts-engine/JlcPartsEngine.ts
@@ -214,7 +214,6 @@ export class JlcPcbPartsEngine implements PartsEngine {
       sourceComponent.ftype === "simple_switch"
     ) {
       const { switches } = await getJlcPartsCached("switches", {
-        switch_type: sourceComponent.type,
         package: jlcpcbPackage,
       })
       return {

--- a/tests/jlc-parts-engine.test.ts
+++ b/tests/jlc-parts-engine.test.ts
@@ -575,4 +575,37 @@ describe("jlcPartsEngine", () => {
       jlcpcb: ["C2222", "C4444", "C1111"],
     })
   })
+
+  // The simple_switch branch passes sourceComponent.type (always the literal
+  // "source_component") as switch_type, so the API is queried with
+  // switch_type=source_component and returns zero switches. Lives inside this
+  // describe so afterEach restores the real fetch even when the assertion
+  // throws.
+  test.failing(
+    "switch search does not send switch_type=source_component",
+    async () => {
+      let requestedUrl = ""
+      globalThis.fetch = (async (url: string) => {
+        requestedUrl = url
+        return {
+          json: async () => ({ switches: [{ lcsc: "2345" }] }),
+        } as Response
+      }) as typeof fetch
+
+      const sw = {
+        type: "source_component",
+        ftype: "simple_switch",
+        source_component_id: "source_component_0",
+        name: "SW1",
+      } as AnySourceComponent
+
+      await jlcPartsEngine.findPart({
+        sourceComponent: sw,
+        footprinterString: "pushbutton",
+      })
+
+      expect(requestedUrl).toContain("/switches/")
+      expect(requestedUrl).not.toContain("switch_type=source_component")
+    },
+  )
 })

--- a/tests/jlc-parts-engine.test.ts
+++ b/tests/jlc-parts-engine.test.ts
@@ -576,36 +576,31 @@ describe("jlcPartsEngine", () => {
     })
   })
 
-  // The simple_switch branch passes sourceComponent.type (always the literal
-  // "source_component") as switch_type, so the API is queried with
-  // switch_type=source_component and returns zero switches. Lives inside this
-  // describe so afterEach restores the real fetch even when the assertion
-  // throws.
-  test.failing(
-    "switch search does not send switch_type=source_component",
-    async () => {
-      let requestedUrl = ""
-      globalThis.fetch = (async (url: string) => {
-        requestedUrl = url
-        return {
-          json: async () => ({ switches: [{ lcsc: "2345" }] }),
-        } as Response
-      }) as typeof fetch
+  // The simple_switch branch used to pass sourceComponent.type (always the
+  // literal "source_component") as switch_type, so the API was queried with
+  // switch_type=source_component and returned zero switches.
+  test("switch search does not send switch_type=source_component", async () => {
+    let requestedUrl = ""
+    globalThis.fetch = (async (url: string) => {
+      requestedUrl = url
+      return {
+        json: async () => ({ switches: [{ lcsc: "2345" }] }),
+      } as Response
+    }) as typeof fetch
 
-      const sw = {
-        type: "source_component",
-        ftype: "simple_switch",
-        source_component_id: "source_component_0",
-        name: "SW1",
-      } as AnySourceComponent
+    const sw = {
+      type: "source_component",
+      ftype: "simple_switch",
+      source_component_id: "source_component_0",
+      name: "SW1",
+    } as AnySourceComponent
 
-      await jlcPartsEngine.findPart({
-        sourceComponent: sw,
-        footprinterString: "pushbutton",
-      })
+    await jlcPartsEngine.findPart({
+      sourceComponent: sw,
+      footprinterString: "pushbutton",
+    })
 
-      expect(requestedUrl).toContain("/switches/")
-      expect(requestedUrl).not.toContain("switch_type=source_component")
-    },
-  )
+    expect(requestedUrl).toContain("/switches/")
+    expect(requestedUrl).not.toContain("switch_type=source_component")
+  })
 })


### PR DESCRIPTION
Closes #34. Fixes the zero-results switch search from #33 — the `simple_switch` branch passed `sourceComponent.type` (always `"source_component"`) as `switch_type`, and jlcsearch returns nothing for that value. Dropped the bogus param like the led/fuse branches do. Flips the failing test to passing.