### PR TITLE
Prefer an exact mfr match when resolving manufacturerPartNumber

### DIFF
--- a/lib/jlc-parts-engine/JlcPartsEngine.ts
+++ b/lib/jlc-parts-engine/JlcPartsEngine.ts
@@ -288,8 +288,16 @@ export class JlcPcbPartsEngine implements PartsEngine {
       const { components } = await getJlcPartsCached("components", {
         search: manufacturerPartNumber,
       })
-      resolvedSupplierPartNumber = components?.[0]
-        ? `C${components[0].lcsc}`
+      // The search is fuzzy and its ranking can put unrelated parts first, so
+      // prefer an exact manufacturer-part-number match over the top result.
+      const exactMatch = components?.find(
+        (c: any) =>
+          typeof c.mfr === "string" &&
+          c.mfr.toLowerCase() === manufacturerPartNumber.toLowerCase(),
+      )
+      const resolvedComponent = exactMatch ?? components?.[0]
+      resolvedSupplierPartNumber = resolvedComponent
+        ? `C${resolvedComponent.lcsc}`
         : undefined
     }
 

--- a/tests/jlc-parts-engine.test.ts
+++ b/tests/jlc-parts-engine.test.ts
@@ -506,4 +506,34 @@ describe("jlcPartsEngine", () => {
       jlcpcb: ["C2222", "C4444", "C1111"],
     })
   })
+
+  test("fetchPartCircuitJson resolves an exact mfr match, not the first fuzzy hit", async () => {
+    const easyEdaRequestBodies: string[] = []
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      if (String(url).includes("/components/list")) {
+        return {
+          json: async () => ({
+            components: [
+              { lcsc: 2907321, mfr: "FRC0805J331 TS" },
+              { lcsc: 165948, mfr: "TYPE-C-31-M-12" },
+            ],
+          }),
+        } as Response
+      }
+      // easyeda's search posts the supplier part number in the request body
+      easyEdaRequestBodies.push(String(init?.body ?? ""))
+      return {} as Response
+    }) as any
+
+    // The easyeda fetch downstream gets a stub response and throws; we only
+    // care which supplier part number it was asked for.
+    try {
+      await jlcPartsEngine.fetchPartCircuitJson!({
+        manufacturerPartNumber: "TYPE-C-31-M-12",
+      })
+    } catch {}
+
+    expect(easyEdaRequestBodies.some((b) => b.includes("C165948"))).toBe(true)
+    expect(easyEdaRequestBodies.some((b) => b.includes("C2907321"))).toBe(false)
+  })
 })


### PR DESCRIPTION
Closes #36. `fetchPartCircuitJson({ manufacturerPartNumber })` took the first fuzzy jlcsearch hit, and the ranking can put unrelated parts first — `TYPE-C-31-M-12` was resolving to an 0805 resistor. Now an exact (case-insensitive) `mfr` match is preferred, falling back to the first result. Adds a deterministic mocked-fetch test, and the live TYPE-C test that's been red on CI passes again.