### PR TITLE
fix: prefer exact manufacturer part number match over first fuzzy hit (#36)

### DIFF
--- a/lib/jlc-parts-engine/JlcPartsEngine.ts
+++ b/lib/jlc-parts-engine/JlcPartsEngine.ts
@@ -284,8 +284,15 @@ export class JlcPcbPartsEngine implements PartsEngine {
       )
       const exactManufacturerPartMatch = components?.find(
         (component: any) =>
+          normalizePartNumber(
+            component.mfr_part_number ??
+              component.mfr_pn ??
+              component.mfrPartNumber ??
+              component.extra?.mfr_part_number ??
+              component.mfr,
+          ) === normalizedManufacturerPartNumber ||
           normalizePartNumber(component.mfr) ===
-          normalizedManufacturerPartNumber,
+            normalizedManufacturerPartNumber,
       )
       const componentMatch = exactManufacturerPartMatch ?? components?.[0]
       resolvedSupplierPartNumber = componentMatch

--- a/tests/mfr-part-number-exact-match.test.ts
+++ b/tests/mfr-part-number-exact-match.test.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "bun:test"
+import { jlcPartsEngine } from "../lib/jlc-parts-engine"
+
+test("fetchPartCircuitJson prefers exact manufacturerPartNumber match over first fuzzy hit", async () => {
+  const result = await jlcPartsEngine.fetchPartCircuitJson!({
+    manufacturerPartNumber: "TYPE-C-31-M-12",
+  })
+
+  expect(result).toBeDefined()
+  expect(Array.isArray(result)).toBe(true)
+
+  const types = result!.map((el: any) => el.type)
+
+  // TYPE-C-31-M-12 should resolve to USB-C connector (C165948) with 12 SMT pads and 4 plated holes
+  expect(types.filter((t: string) => t === "pcb_smtpad").length).toBe(12)
+  expect(types.filter((t: string) => t === "pcb_plated_hole").length).toBe(4)
+}, 20000)


### PR DESCRIPTION
## Summary

Closes #36

When searching for components by `manufacturerPartNumber`, `fetchPartCircuitJson` previously checked `normalizePartNumber(component.mfr)` against `normalizedManufacturerPartNumber`. Since `component.mfr` stores the manufacturer's name (e.g. "Korean Hroparts Elec") rather than part number, exact matches always evaluated to undefined, causing resolution to fall back to `components[0]` (which could be an unrelated fuzzy hit, such as a 0805 resistor).

This PR updates the exact match comparison to inspect `component.mfr_part_number`, `component.mfr_pn`, and related fields before falling back to fuzzy hits.

## Testing

- Added unit test `tests/mfr-part-number-exact-match.test.ts` verifying `TYPE-C-31-M-12` resolves to the exact USB-C connector (C165948) with 12 SMT pads and 4 plated holes.
- All 27 tests pass 100%.
