### PR TITLE
Bump easyeda to preserve proxy HTTP status

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@tscircuit/props": "^0.0.513",
         "@types/bun": "latest",
         "circuit-json": "^0.0.421",
-        "easyeda": "^0.0.267",
+        "easyeda": "^0.0.277",
         "tsup": "^8.4.0",
       },
       "peerDependencies": {
@@ -182,7 +182,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.267", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-bBIIK6h5qKA0Ks6VgGrB68AMDsn7GhHJyF53q2Hi480Rfni4HXdM3puqBrXlBG96V7FsyQfa9U1r93F6K+hHtw=="],
+    "easyeda": ["easyeda@0.0.277", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-OIRPyjsXxKoWJtuAcyLYMIrgGf7X/tTbKLtWHScsoXMP3MDbmCk/L1jFC1R7++5sndVVaHxi3KhTioe+mjkZIg=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@tscircuit/props": "^0.0.513",
     "@types/bun": "latest",
     "circuit-json": "^0.0.421",
-    "easyeda": "^0.0.267",
+    "easyeda": "^0.0.277",
     "tsup": "^8.4.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Bump `easyeda` from `0.0.267` to `0.0.277`.

## Why

The previous EasyEDA version converted every failed search response into the same generic error. EasyEDA 0.0.277 retains the HTTP status in the propagated error message, allowing downstream consumers to distinguish authentication 401 responses from other proxy or upstream failures.

## Validation

- `bun test` — 26 tests passed
- `bun run build`
- `bun run format:check`