### PR TITLE
Add DigiKey parts engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # parts-engine
-The tscircuit platform parts engine
+
+The tscircuit platform parts engine.
+
+## Supplier engines
+
+```ts
+import {
+  digikeyPartsEngine,
+  jlcPartsEngine,
+  DigiKeyPartsEngine,
+} from "@tscircuit/parts-engine"
+```
+
+`digikeyPartsEngine.findPart(...)` queries
+`https://digikeysearch.tscircuit.com`, which provides the same category route
+shape as jlcsearch while caching DigiKey Product Information V4 calls. Use
+`new DigiKeyPartsEngine({ platformFetch, apiBaseUrl })` to inject a platform
+fetch implementation or a test/self-hosted endpoint.

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
 export * from "./lib/jlc-parts-engine"
+export * from "./lib/digikey-parts-engine"

--- a/lib/digikey-parts-engine/DigiKeyPartsEngine.ts
+++ b/lib/digikey-parts-engine/DigiKeyPartsEngine.ts
@@ -1,0 +1,183 @@
+import type { PartsEngine } from "@tscircuit/props"
+import { getJlcpcbPackageName } from "../footprint-translators"
+import { getPinHeaderSearchParams } from "../jlc-parts-engine/get-pin-header-search-params"
+import {
+  getDigiKeyPartsCached,
+  withDigiKeyStockPreference,
+} from "./digikey-parts-cache"
+import type { DigiKeyPartsEngineOptions, DigiKeySearchPart } from "./types"
+
+export class DigiKeyPartsEngine implements PartsEngine {
+  private readonly platformFetch: DigiKeyPartsEngineOptions["platformFetch"]
+  private readonly apiBaseUrl: string | undefined
+
+  constructor(options: DigiKeyPartsEngineOptions = {}) {
+    this.platformFetch = options.platformFetch
+    this.apiBaseUrl = options.apiBaseUrl
+    this.findPart = this.findPart.bind(this)
+  }
+
+  private async getCategoryParts(
+    path: string,
+    responseKey: string,
+    params: Record<string, string | number | boolean | undefined>,
+  ): Promise<DigiKeySearchPart[]> {
+    const response = await getDigiKeyPartsCached(path, params, {
+      platformFetch: this.platformFetch,
+      apiBaseUrl: this.apiBaseUrl,
+    })
+    return response[responseKey] ?? []
+  }
+
+  private async getKeywordParts(query: string): Promise<DigiKeySearchPart[]> {
+    const response = await getDigiKeyPartsCached(
+      "/api/search",
+      { q: query, limit: 20 },
+      {
+        platformFetch: this.platformFetch,
+        apiBaseUrl: this.apiBaseUrl,
+      },
+    )
+    return response.components ?? []
+  }
+
+  private toSupplierPartNumbers(parts: DigiKeySearchPart[]) {
+    return {
+      digikey: withDigiKeyStockPreference(parts)
+        .map((part) => part.digikey_product_number)
+        .filter(Boolean)
+        .slice(0, 3),
+    }
+  }
+
+  async findPart({
+    sourceComponent,
+    footprinterString,
+  }: Parameters<PartsEngine["findPart"]>[0]) {
+    if (sourceComponent.type !== "source_component") return {}
+
+    const packageName = getJlcpcbPackageName(footprinterString)
+
+    if (sourceComponent.ftype === "simple_resistor") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/resistors/list", "resistors", {
+          resistance: sourceComponent.resistance,
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_capacitor") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/capacitors/list", "capacitors", {
+          capacitance: sourceComponent.capacitance,
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_pin_header") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts(
+          "/headers/list",
+          "headers",
+          getPinHeaderSearchParams(sourceComponent, footprinterString),
+        ),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_potentiometer") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/potentiometers/list", "potentiometers", {
+          resistance: sourceComponent.max_resistance,
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_diode") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/diodes/list", "diodes", {
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_transistor") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts(
+          "/bjt_transistors/list",
+          "bjt_transistors",
+          { package: packageName },
+        ),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_mosfet") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/mosfets/list", "mosfets", {
+          package: packageName,
+          channel_type: sourceComponent.channel_type,
+          mosfet_mode: sourceComponent.mosfet_mode,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_switch") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/switches/list", "switches", {
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_led") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/leds/list", "leds", {
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_fuse") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/fuses/list", "fuses", {
+          package: packageName,
+        }),
+      )
+    }
+
+    if (
+      sourceComponent.ftype === "simple_connector" &&
+      sourceComponent.standard === "usb_c"
+    ) {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts(
+          "/usb_c_connectors/list",
+          "usb_c_connectors",
+          { package: packageName },
+        ),
+      )
+    }
+
+    const keywordByFtype: Partial<
+      Record<typeof sourceComponent.ftype, string>
+    > = {
+      simple_chip: "integrated circuit",
+      simple_power_source: "power supply",
+      simple_inductor: "inductor",
+      simple_crystal: "crystal",
+      simple_resonator: "resonator",
+    }
+    const keyword = keywordByFtype[sourceComponent.ftype]
+    if (keyword) {
+      return this.toSupplierPartNumbers(
+        await this.getKeywordParts(
+          [keyword, packageName].filter(Boolean).join(" "),
+        ),
+      )
+    }
+
+    return {}
+  }
+}

--- a/lib/digikey-parts-engine/digikey-parts-cache.ts
+++ b/lib/digikey-parts-engine/digikey-parts-cache.ts
@@ -1,0 +1,53 @@
+import type { PlatformFetch } from "../jlc-parts-engine/types"
+import type { DigiKeySearchPart } from "./types"
+
+export const digikeyCache = new Map<string, unknown>()
+
+const normalizeBaseUrl = (baseUrl: string): string => baseUrl.replace(/\/$/, "")
+
+export const getDigiKeyPartsCached = async (
+  path: string,
+  params: Record<string, string | number | boolean | undefined>,
+  options: {
+    platformFetch?: PlatformFetch
+    apiBaseUrl?: string
+  } = {},
+): Promise<Record<string, DigiKeySearchPart[]>> => {
+  const platformFetch = options.platformFetch ?? globalThis.fetch
+  const baseUrl = normalizeBaseUrl(
+    options.apiBaseUrl ?? "https://digikeysearch.tscircuit.com",
+  )
+  const url = new URL(path, `${baseUrl}/`)
+  for (const [name, value] of Object.entries(params)) {
+    if (value !== undefined && value !== "") {
+      url.searchParams.set(name, String(value))
+    }
+  }
+  url.searchParams.set("json", "true")
+
+  const cacheKey = url.toString()
+  const cached = digikeyCache.get(cacheKey)
+  if (cached) return cached as Record<string, DigiKeySearchPart[]>
+
+  const response = await platformFetch(url)
+  if (!response.ok) {
+    throw new Error(
+      `DigiKey search failed (${response.status}): ${await response.text()}`,
+    )
+  }
+  const responseJson = (await response.json()) as Record<
+    string,
+    DigiKeySearchPart[]
+  >
+  digikeyCache.set(cacheKey, responseJson)
+  return responseJson
+}
+
+export const withDigiKeyStockPreference = (
+  parts: DigiKeySearchPart[] | undefined,
+): DigiKeySearchPart[] =>
+  [...(parts ?? [])].sort(
+    (a, b) =>
+      Number(b.normally_stocking ?? false) -
+        Number(a.normally_stocking ?? false) || (b.stock ?? 0) - (a.stock ?? 0),
+  )

--- a/lib/digikey-parts-engine/index.ts
+++ b/lib/digikey-parts-engine/index.ts
@@ -1,0 +1,11 @@
+import { DigiKeyPartsEngine } from "./DigiKeyPartsEngine"
+
+export { DigiKeyPartsEngine }
+export {
+  digikeyCache,
+  getDigiKeyPartsCached,
+  withDigiKeyStockPreference,
+} from "./digikey-parts-cache"
+export type { DigiKeyPartsEngineOptions, DigiKeySearchPart } from "./types"
+
+export const digikeyPartsEngine = new DigiKeyPartsEngine()

--- a/lib/digikey-parts-engine/types.ts
+++ b/lib/digikey-parts-engine/types.ts
@@ -1,0 +1,18 @@
+import type { PlatformFetch } from "../jlc-parts-engine/types"
+
+export type DigiKeyPartsEngineOptions = {
+  platformFetch?: PlatformFetch
+  apiBaseUrl?: string
+}
+
+export type DigiKeySearchPart = {
+  digikey_product_number: string
+  supplier_part_number?: string
+  mfr: string
+  manufacturer?: string
+  package?: string
+  description?: string
+  stock: number
+  price?: number
+  normally_stocking?: boolean
+}

--- a/tests/digikey-parts-engine.test.ts
+++ b/tests/digikey-parts-engine.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { DigiKeyPartsEngine, digikeyCache } from "../lib/digikey-parts-engine"
+
+afterEach(() => digikeyCache.clear())
+
+describe("DigiKeyPartsEngine", () => {
+  it("maps resistor constraints to the compatible DigiKey category route", async () => {
+    const requests: URL[] = []
+    const engine = new DigiKeyPartsEngine({
+      apiBaseUrl: "https://digikey.example.test",
+      platformFetch: async (input) => {
+        requests.push(new URL(String(input)))
+        return new Response(
+          JSON.stringify({
+            resistors: [
+              {
+                digikey_product_number: "LOW-STOCK-ND",
+                mfr: "LOW",
+                stock: 10,
+              },
+              {
+                digikey_product_number: "HIGH-STOCK-ND",
+                mfr: "HIGH",
+                stock: 1000,
+                normally_stocking: true,
+              },
+            ],
+          }),
+          { status: 200 },
+        )
+      },
+    })
+
+    const result = await engine.findPart({
+      sourceComponent: {
+        type: "source_component",
+        source_component_id: "source_component_0",
+        name: "R1",
+        ftype: "simple_resistor",
+        resistance: 10_000,
+      },
+      footprinterString: "0402",
+    })
+
+    expect(result).toEqual({
+      digikey: ["HIGH-STOCK-ND", "LOW-STOCK-ND"],
+    })
+    expect(requests).toHaveLength(1)
+    expect(requests[0].pathname).toBe("/resistors/list")
+    expect(requests[0].searchParams.get("resistance")).toBe("10000")
+    expect(requests[0].searchParams.get("package")).toBe("0402")
+    expect(requests[0].searchParams.get("json")).toBe("true")
+  })
+
+  it("caches identical lookups in-process", async () => {
+    let calls = 0
+    const engine = new DigiKeyPartsEngine({
+      apiBaseUrl: "https://digikey.example.test",
+      platformFetch: async () => {
+        calls += 1
+        return new Response(JSON.stringify({ leds: [] }), { status: 200 })
+      },
+    })
+    const params = {
+      sourceComponent: {
+        type: "source_component" as const,
+        source_component_id: "source_component_0",
+        name: "D1",
+        ftype: "simple_led" as const,
+        color: "red",
+      },
+      footprinterString: "0603",
+    }
+
+    await engine.findPart(params)
+    await engine.findPart(params)
+    expect(calls).toBe(1)
+  })
+})

--- a/tests/digikey-parts-engine.test.ts
+++ b/tests/digikey-parts-engine.test.ts
@@ -46,10 +46,12 @@ describe("DigiKeyPartsEngine", () => {
       digikey: ["HIGH-STOCK-ND", "LOW-STOCK-ND"],
     })
     expect(requests).toHaveLength(1)
-    expect(requests[0].pathname).toBe("/resistors/list")
-    expect(requests[0].searchParams.get("resistance")).toBe("10000")
-    expect(requests[0].searchParams.get("package")).toBe("0402")
-    expect(requests[0].searchParams.get("json")).toBe("true")
+    const request = requests[0]
+    if (!request) throw new Error("Expected one DigiKey search request")
+    expect(request.pathname).toBe("/resistors/list")
+    expect(request.searchParams.get("resistance")).toBe("10000")
+    expect(request.searchParams.get("package")).toBe("0402")
+    expect(request.searchParams.get("json")).toBe("true")
   })
 
   it("caches identical lookups in-process", async () => {


### PR DESCRIPTION
## Summary

- add a `DigiKeyPartsEngine` and default `digikeyPartsEngine` export
- map supported source-component types to the category routes exposed by [digikeysearch.tscircuit.com](https://digikeysearch.tscircuit.com)
- return stock-preferred DigiKey product numbers using the existing `PartsEngine` interface
- cache identical lookups in-process and support injected fetch/base URL implementations
- document the new supplier engine

## Why

This connects parts-engine to the new cached DigiKey Product Information search service at [tscircuit/digikeysearch.tscircuit.com](https://github.com/tscircuit/digikeysearch.tscircuit.com), enabling DigiKey supplier candidates without exposing DigiKey API credentials or consuming upstream quota for every lookup.

## Developer impact

Consumers can import `digikeyPartsEngine` directly or construct `DigiKeyPartsEngine` with a custom `platformFetch` or `apiBaseUrl`. Existing JLC behavior and exports remain unchanged.

## Validation

- `bun run format:check`
- `bun run build`
- `bun test` — 29 tests passed