### PR TITLE
Add Mouser parts engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ import {
   digikeyPartsEngine,
   jlcPartsEngine,
   DigiKeyPartsEngine,
+  mouserPartsEngine,
+  MouserPartsEngine,
 } from "@tscircuit/parts-engine"
 ```
 
@@ -16,4 +18,10 @@ import {
 `https://digikeysearch.tscircuit.com`, which provides the same category route
 shape as jlcsearch while caching DigiKey Product Information V4 calls. Use
 `new DigiKeyPartsEngine({ platformFetch, apiBaseUrl })` to inject a platform
+fetch implementation or a test/self-hosted endpoint.
+
+`mouserPartsEngine.findPart(...)` queries
+`https://mousersearch.tscircuit.com`, which exposes the same category route
+shape while caching Mouser Search API calls. Use
+`new MouserPartsEngine({ platformFetch, apiBaseUrl })` to inject a platform
 fetch implementation or a test/self-hosted endpoint.

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
 export * from "./lib/jlc-parts-engine"
 export * from "./lib/digikey-parts-engine"
+export * from "./lib/mouser-parts-engine"

--- a/lib/mouser-parts-engine/MouserPartsEngine.ts
+++ b/lib/mouser-parts-engine/MouserPartsEngine.ts
@@ -1,0 +1,183 @@
+import type { PartsEngine } from "@tscircuit/props"
+import { getJlcpcbPackageName } from "../footprint-translators"
+import { getPinHeaderSearchParams } from "../jlc-parts-engine/get-pin-header-search-params"
+import {
+  getMouserPartsCached,
+  withMouserStockPreference,
+} from "./mouser-parts-cache"
+import type { MouserPartsEngineOptions, MouserSearchPart } from "./types"
+
+export class MouserPartsEngine implements PartsEngine {
+  private readonly platformFetch: MouserPartsEngineOptions["platformFetch"]
+  private readonly apiBaseUrl: string | undefined
+
+  constructor(options: MouserPartsEngineOptions = {}) {
+    this.platformFetch = options.platformFetch
+    this.apiBaseUrl = options.apiBaseUrl
+    this.findPart = this.findPart.bind(this)
+  }
+
+  private async getCategoryParts(
+    path: string,
+    responseKey: string,
+    params: Record<string, string | number | boolean | undefined>,
+  ): Promise<MouserSearchPart[]> {
+    const response = await getMouserPartsCached(path, params, {
+      platformFetch: this.platformFetch,
+      apiBaseUrl: this.apiBaseUrl,
+    })
+    return response[responseKey] ?? []
+  }
+
+  private async getKeywordParts(query: string): Promise<MouserSearchPart[]> {
+    const response = await getMouserPartsCached(
+      "/api/search",
+      { q: query, limit: 20 },
+      {
+        platformFetch: this.platformFetch,
+        apiBaseUrl: this.apiBaseUrl,
+      },
+    )
+    return response.components ?? []
+  }
+
+  private toSupplierPartNumbers(parts: MouserSearchPart[]) {
+    return {
+      mouser: withMouserStockPreference(parts)
+        .map((part) => part.mouser_product_number)
+        .filter(Boolean)
+        .slice(0, 3),
+    }
+  }
+
+  async findPart({
+    sourceComponent,
+    footprinterString,
+  }: Parameters<PartsEngine["findPart"]>[0]) {
+    if (sourceComponent.type !== "source_component") return {}
+
+    const packageName = getJlcpcbPackageName(footprinterString)
+
+    if (sourceComponent.ftype === "simple_resistor") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/resistors/list", "resistors", {
+          resistance: sourceComponent.resistance,
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_capacitor") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/capacitors/list", "capacitors", {
+          capacitance: sourceComponent.capacitance,
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_pin_header") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts(
+          "/headers/list",
+          "headers",
+          getPinHeaderSearchParams(sourceComponent, footprinterString),
+        ),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_potentiometer") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/potentiometers/list", "potentiometers", {
+          resistance: sourceComponent.max_resistance,
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_diode") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/diodes/list", "diodes", {
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_transistor") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts(
+          "/bjt_transistors/list",
+          "bjt_transistors",
+          { package: packageName },
+        ),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_mosfet") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/mosfets/list", "mosfets", {
+          package: packageName,
+          channel_type: sourceComponent.channel_type,
+          mosfet_mode: sourceComponent.mosfet_mode,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_switch") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/switches/list", "switches", {
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_led") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/leds/list", "leds", {
+          package: packageName,
+        }),
+      )
+    }
+
+    if (sourceComponent.ftype === "simple_fuse") {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts("/fuses/list", "fuses", {
+          package: packageName,
+        }),
+      )
+    }
+
+    if (
+      sourceComponent.ftype === "simple_connector" &&
+      sourceComponent.standard === "usb_c"
+    ) {
+      return this.toSupplierPartNumbers(
+        await this.getCategoryParts(
+          "/usb_c_connectors/list",
+          "usb_c_connectors",
+          { package: packageName },
+        ),
+      )
+    }
+
+    const keywordByFtype: Partial<
+      Record<typeof sourceComponent.ftype, string>
+    > = {
+      simple_chip: "integrated circuit",
+      simple_power_source: "power supply",
+      simple_inductor: "inductor",
+      simple_crystal: "crystal",
+      simple_resonator: "resonator",
+    }
+    const keyword = keywordByFtype[sourceComponent.ftype]
+    if (keyword) {
+      return this.toSupplierPartNumbers(
+        await this.getKeywordParts(
+          [keyword, packageName].filter(Boolean).join(" "),
+        ),
+      )
+    }
+
+    return {}
+  }
+}

--- a/lib/mouser-parts-engine/index.ts
+++ b/lib/mouser-parts-engine/index.ts
@@ -1,0 +1,11 @@
+import { MouserPartsEngine } from "./MouserPartsEngine"
+
+export { MouserPartsEngine }
+export {
+  mouserCache,
+  getMouserPartsCached,
+  withMouserStockPreference,
+} from "./mouser-parts-cache"
+export type { MouserPartsEngineOptions, MouserSearchPart } from "./types"
+
+export const mouserPartsEngine = new MouserPartsEngine()

--- a/lib/mouser-parts-engine/mouser-parts-cache.ts
+++ b/lib/mouser-parts-engine/mouser-parts-cache.ts
@@ -1,0 +1,53 @@
+import type { PlatformFetch } from "../jlc-parts-engine/types"
+import type { MouserSearchPart } from "./types"
+
+export const mouserCache = new Map<string, unknown>()
+
+const normalizeBaseUrl = (baseUrl: string): string => baseUrl.replace(/\/$/, "")
+
+export const getMouserPartsCached = async (
+  path: string,
+  params: Record<string, string | number | boolean | undefined>,
+  options: {
+    platformFetch?: PlatformFetch
+    apiBaseUrl?: string
+  } = {},
+): Promise<Record<string, MouserSearchPart[]>> => {
+  const platformFetch = options.platformFetch ?? globalThis.fetch
+  const baseUrl = normalizeBaseUrl(
+    options.apiBaseUrl ?? "https://mousersearch.tscircuit.com",
+  )
+  const url = new URL(path, `${baseUrl}/`)
+  for (const [name, value] of Object.entries(params)) {
+    if (value !== undefined && value !== "") {
+      url.searchParams.set(name, String(value))
+    }
+  }
+  url.searchParams.set("json", "true")
+
+  const cacheKey = url.toString()
+  const cached = mouserCache.get(cacheKey)
+  if (cached) return cached as Record<string, MouserSearchPart[]>
+
+  const response = await platformFetch(url)
+  if (!response.ok) {
+    throw new Error(
+      `Mouser search failed (${response.status}): ${await response.text()}`,
+    )
+  }
+  const responseJson = (await response.json()) as Record<
+    string,
+    MouserSearchPart[]
+  >
+  mouserCache.set(cacheKey, responseJson)
+  return responseJson
+}
+
+export const withMouserStockPreference = (
+  parts: MouserSearchPart[] | undefined,
+): MouserSearchPart[] =>
+  [...(parts ?? [])].sort(
+    (a, b) =>
+      Number(b.normally_stocking ?? false) -
+        Number(a.normally_stocking ?? false) || (b.stock ?? 0) - (a.stock ?? 0),
+  )

--- a/lib/mouser-parts-engine/types.ts
+++ b/lib/mouser-parts-engine/types.ts
@@ -1,0 +1,18 @@
+import type { PlatformFetch } from "../jlc-parts-engine/types"
+
+export type MouserPartsEngineOptions = {
+  platformFetch?: PlatformFetch
+  apiBaseUrl?: string
+}
+
+export type MouserSearchPart = {
+  mouser_product_number: string
+  supplier_part_number?: string
+  mfr: string
+  manufacturer?: string
+  package?: string
+  description?: string
+  stock: number
+  price?: number
+  normally_stocking?: boolean
+}

--- a/tests/mouser-parts-engine.test.ts
+++ b/tests/mouser-parts-engine.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { MouserPartsEngine, mouserCache } from "../lib/mouser-parts-engine"
+
+afterEach(() => mouserCache.clear())
+
+describe("MouserPartsEngine", () => {
+  it("maps resistor constraints to the compatible Mouser category route", async () => {
+    const requests: URL[] = []
+    const engine = new MouserPartsEngine({
+      apiBaseUrl: "https://mouser.example.test",
+      platformFetch: async (input) => {
+        requests.push(new URL(String(input)))
+        return new Response(
+          JSON.stringify({
+            resistors: [
+              {
+                mouser_product_number: "LOW-STOCK-ND",
+                mfr: "LOW",
+                stock: 10,
+              },
+              {
+                mouser_product_number: "HIGH-STOCK-ND",
+                mfr: "HIGH",
+                stock: 1000,
+                normally_stocking: true,
+              },
+            ],
+          }),
+          { status: 200 },
+        )
+      },
+    })
+
+    const result = await engine.findPart({
+      sourceComponent: {
+        type: "source_component",
+        source_component_id: "source_component_0",
+        name: "R1",
+        ftype: "simple_resistor",
+        resistance: 10_000,
+      },
+      footprinterString: "0402",
+    })
+
+    expect(result).toEqual({
+      mouser: ["HIGH-STOCK-ND", "LOW-STOCK-ND"],
+    })
+    expect(requests).toHaveLength(1)
+    const request = requests[0]
+    if (!request) throw new Error("Expected one Mouser search request")
+    expect(request.pathname).toBe("/resistors/list")
+    expect(request.searchParams.get("resistance")).toBe("10000")
+    expect(request.searchParams.get("package")).toBe("0402")
+    expect(request.searchParams.get("json")).toBe("true")
+  })
+
+  it("caches identical lookups in-process", async () => {
+    let calls = 0
+    const engine = new MouserPartsEngine({
+      apiBaseUrl: "https://mouser.example.test",
+      platformFetch: async () => {
+        calls += 1
+        return new Response(JSON.stringify({ leds: [] }), { status: 200 })
+      },
+    })
+    const params = {
+      sourceComponent: {
+        type: "source_component" as const,
+        source_component_id: "source_component_0",
+        name: "D1",
+        ftype: "simple_led" as const,
+        color: "red",
+      },
+      footprinterString: "0603",
+    }
+
+    await engine.findPart(params)
+    await engine.findPart(params)
+    expect(calls).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

- add a `MouserPartsEngine` backed by `mousersearch.tscircuit.com`
- map source-component constraints onto the jlcsearch-compatible category routes
- cache repeated lookups and prefer normally stocked, higher-stock parts
- export the engine, singleton, cache helpers, and public types

## Why

This gives tscircuit consumers supplier part-number candidates from Mouser through the same `PartsEngine` interface already used for JLCPCB and DigiKey. Upstream quota and product normalization are handled by the separately deployed Cloudflare/D1 service.

## Validation

- `bunx tsc --noEmit`
- `bun run build`
- `bun test` (31 tests passing)