### PR TITLE
fix: parse C11337 whitespace text metadata

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@tscircuit/props": "^0.0.513",
         "@types/bun": "latest",
         "circuit-json": "^0.0.421",
-        "easyeda": "^0.0.277",
+        "easyeda": "^0.0.284",
         "tsup": "^8.4.0",
       },
       "peerDependencies": {
@@ -182,7 +182,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "easyeda": ["easyeda@0.0.277", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-OIRPyjsXxKoWJtuAcyLYMIrgGf7X/tTbKLtWHScsoXMP3MDbmCk/L1jFC1R7++5sndVVaHxi3KhTioe+mjkZIg=="],
+    "easyeda": ["easyeda@0.0.284", "", { "peerDependencies": { "typescript": "^5.5.2", "zod": "3" }, "bin": { "easyeda-converter": "dist/main.cjs", "easyeda": "dist/main.cjs" } }, "sha512-CcyM4QwZe5oSRPQvHRcO7VDAL9ujrj2uydJuxltvcIw50RLOrcv3bEVrZ6FT/3e1B+ockUf+j9zpzNL4qGz6KA=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@tscircuit/props": "^0.0.513",
     "@types/bun": "latest",
     "circuit-json": "^0.0.421",
-    "easyeda": "^0.0.277",
+    "easyeda": "^0.0.284",
     "tsup": "^8.4.0"
   },
   "scripts": {

--- a/tests/c11337-whitespace-text-fields.test.ts
+++ b/tests/c11337-whitespace-text-fields.test.ts
@@ -78,8 +78,16 @@ test("fetchPartCircuitJson parses C11337 whitespace-only text fields", async () 
 
   expect(conversionResult).toMatchInlineSnapshot(`
     {
-      "message": "[ { "received": " ", "code": "invalid_enum_value", "options": [ "normal", "italic" ], "path": [ "fontStyle" ], "message": "Invalid enum value. Expected 'normal' | 'italic', received ' '" } ]",
-      "status": "error",
+      "elementTypeCounts": {
+        "cad_component": 1,
+        "pcb_component": 1,
+        "pcb_courtyard_outline": 1,
+        "pcb_silkscreen_path": 9,
+        "pcb_smtpad": 5,
+        "source_component": 1,
+        "source_port": 5,
+      },
+      "status": "success",
     }
   `)
 })


### PR DESCRIPTION
## Fix

This is the child fix for #46. It updates the EasyEDA parser from 0.0.277 to the already-published 0.0.284 release, which normalizes whitespace-only text style fields.

## Snapshot diff

The parent repro snapshots C11337 as an `invalid_enum_value` parser error. This child updates the same inline result snapshot to successful Circuit JSON element counts.

## Validation

- `bun test` — 32 pass, 0 fail
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`

Branch chain: #46 → this PR.