### PR TITLE
Add JST connector part selection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,9 @@
       "name": "@tscircuit/parts-engine",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@tscircuit/props": "^0.0.513",
+        "@tscircuit/props": "^0.0.622",
         "@types/bun": "latest",
-        "circuit-json": "^0.0.421",
+        "circuit-json": "^0.0.469",
         "easyeda": "^0.0.284",
         "tsup": "^8.4.0",
       },
@@ -140,7 +140,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.40.0", "", { "os": "win32", "cpu": "x64" }, "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ=="],
 
-    "@tscircuit/props": ["@tscircuit/props@0.0.513", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-IhIW+ulA0dVUFdSihArBD1fyPGsAEhJlQ+ucBOYLpAMVYJyn1KUxs1hdmwSCOU8q4UfK7CompI9GU8viKQVWRA=="],
+    "@tscircuit/props": ["@tscircuit/props@0.0.622", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-BYR0kEdMtNFSLzh5T3np55NyatXMAMIRLx+TXXvp58gs/BYYYUhR75O8mIeAgvBhzCi78efMSLCLJ5+LUSdVUg=="],
 
     "@types/bun": ["@types/bun@1.2.10", "", { "dependencies": { "bun-types": "1.2.10" } }, "sha512-eilv6WFM3M0c9ztJt7/g80BDusK98z/FrFwseZgT4bXCq2vPhXD4z8R3oddmAn+R/Nmz9vBn4kweJKmGTZj+lg=="],
 
@@ -166,7 +166,7 @@
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
-    "circuit-json": ["circuit-json@0.0.421", "", {}, "sha512-1zb0o4gM4fAL+2liV5i/wvom7SCdr/6Nc0hsYLFzSWnQ3yWpQHQxhDgvNEQ/FTZVKIAhhJ3mD9XbwduwfkJCrA=="],
+    "circuit-json": ["circuit-json@0.0.469", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-ThMs+rYs7KtQUj/s19zyHN50I4MJIZRQfpEyaxd00YBu0f5nuF6oOTPulJpUALxVBZX42u/ooJS+qyU+7o0l/w=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -191,6 +191,8 @@
     "fdir": ["fdir@6.4.4", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "format-si-unit": ["format-si-unit@0.0.12", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-HeYwGhbKefmyyVmZrlp1S/RlnEOAoHkncQreW1RTvSmDSZ3BFHfDlIg2OOnDFyr/7n5bs//YXvUHzRhoVuPYgA=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/lib/jlc-parts-engine/JlcPartsEngine.ts
+++ b/lib/jlc-parts-engine/JlcPartsEngine.ts
@@ -6,6 +6,10 @@ import {
 } from "easyeda/browser"
 import { getJlcpcbPackageName } from "../footprint-translators/index"
 import { getFetchWithEasyEdaProxy } from "./getFetchWithEasyEdaProxy"
+import {
+  getJstConnectorSearchConfig,
+  isCompatiblePcbMountJstConnector,
+} from "./get-jst-connector-search-config"
 import { getPinHeaderSearchParams } from "./get-pin-header-search-params"
 import { getJlcPartsCached, withBasicPartPreference } from "./jlc-parts-cache"
 import type { JlcPcbPartsEngineOptions, PlatformFetch } from "./types"
@@ -258,6 +262,33 @@ export class JlcPcbPartsEngine implements PartsEngine {
       return {
         jlcpcb: withBasicPartPreference(usb_c_connectors)
           .map((c: any) => `C${c.lcsc}`)
+          .slice(0, 3),
+      }
+    } else if (
+      sourceComponent.type === "source_component" &&
+      sourceComponent.ftype === "simple_connector"
+    ) {
+      const searchConfig = getJstConnectorSearchConfig(sourceComponent.standard)
+
+      if (!searchConfig || !sourceComponent.pin_count) {
+        return {}
+      }
+
+      const { jst_connectors } = await getJlcPartsCached("jst_connectors", {
+        pitch_mm: searchConfig.pitchMm,
+        num_pins: sourceComponent.pin_count,
+      })
+      const compatiblePcbMountConnectors = jst_connectors?.filter(
+        (connector: any) =>
+          isCompatiblePcbMountJstConnector(
+            connector,
+            searchConfig.compatibleReferenceSeries,
+          ),
+      )
+
+      return {
+        jlcpcb: withBasicPartPreference(compatiblePcbMountConnectors)
+          .map((connector: any) => `C${connector.lcsc}`)
           .slice(0, 3),
       }
     }

--- a/lib/jlc-parts-engine/get-jst-connector-search-config.ts
+++ b/lib/jlc-parts-engine/get-jst-connector-search-config.ts
@@ -1,0 +1,53 @@
+import type { SourceSimpleConnectorStandard } from "circuit-json"
+
+type JstConnectorStandard = Extract<
+  SourceSimpleConnectorStandard,
+  `jst_${string}`
+>
+
+type JstConnectorSearchConfig = {
+  pitchMm: number
+  compatibleReferenceSeries: string[]
+}
+
+type JstConnector = {
+  reference_series?: string
+  attributes?: string | Record<string, unknown>
+}
+
+const jstConnectorSearchConfigByStandard = {
+  jst_sh: {
+    pitchMm: 1,
+    compatibleReferenceSeries: ["SH", "SR/SZ"],
+  },
+  jst_gh: { pitchMm: 1.25, compatibleReferenceSeries: ["GH"] },
+  jst_zh: { pitchMm: 1.5, compatibleReferenceSeries: ["ZH"] },
+  jst_ph: { pitchMm: 2, compatibleReferenceSeries: ["PH"] },
+  jst_xh: { pitchMm: 2.5, compatibleReferenceSeries: ["XH"] },
+  jst_vh: { pitchMm: 3.96, compatibleReferenceSeries: ["VH"] },
+} satisfies Record<JstConnectorStandard, JstConnectorSearchConfig>
+
+export const getJstConnectorSearchConfig = (
+  standard: SourceSimpleConnectorStandard | undefined,
+): JstConnectorSearchConfig | undefined => {
+  if (!standard || !(standard in jstConnectorSearchConfigByStandard)) {
+    return undefined
+  }
+
+  return jstConnectorSearchConfigByStandard[standard as JstConnectorStandard]
+}
+
+const hasPcbPins = (attributes: JstConnector["attributes"]): boolean => {
+  if (typeof attributes === "string") {
+    return attributes.includes('"Pins Structure"')
+  }
+
+  return Boolean(attributes && Object.hasOwn(attributes, "Pins Structure"))
+}
+
+export const isCompatiblePcbMountJstConnector = (
+  connector: JstConnector,
+  compatibleReferenceSeries: string[],
+): boolean =>
+  compatibleReferenceSeries.includes(connector.reference_series ?? "") &&
+  hasPcbPins(connector.attributes)

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@tscircuit/props": "^0.0.513",
+    "@tscircuit/props": "^0.0.622",
     "@types/bun": "latest",
-    "circuit-json": "^0.0.421",
+    "circuit-json": "^0.0.469",
     "easyeda": "^0.0.284",
     "tsup": "^8.4.0"
   },

--- a/tests/get-jst-connector-search-config.test.ts
+++ b/tests/get-jst-connector-search-config.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { getJstConnectorSearchConfig } from "../lib/jlc-parts-engine/get-jst-connector-search-config"
+
+test("maps JST standards to their pitches and catalog reference series", () => {
+  expect(getJstConnectorSearchConfig("jst_sh")).toEqual({
+    pitchMm: 1,
+    compatibleReferenceSeries: ["SH", "SR/SZ"],
+  })
+  expect(getJstConnectorSearchConfig("jst_gh")).toEqual({
+    pitchMm: 1.25,
+    compatibleReferenceSeries: ["GH"],
+  })
+  expect(getJstConnectorSearchConfig("jst_zh")).toEqual({
+    pitchMm: 1.5,
+    compatibleReferenceSeries: ["ZH"],
+  })
+  expect(getJstConnectorSearchConfig("jst_ph")).toEqual({
+    pitchMm: 2,
+    compatibleReferenceSeries: ["PH"],
+  })
+  expect(getJstConnectorSearchConfig("jst_xh")).toEqual({
+    pitchMm: 2.5,
+    compatibleReferenceSeries: ["XH"],
+  })
+  expect(getJstConnectorSearchConfig("jst_vh")).toEqual({
+    pitchMm: 3.96,
+    compatibleReferenceSeries: ["VH"],
+  })
+  expect(getJstConnectorSearchConfig("usb_c")).toBeUndefined()
+})

--- a/tests/jlc-parts-engine.test.ts
+++ b/tests/jlc-parts-engine.test.ts
@@ -128,6 +128,34 @@ describe("jlcPartsEngine", () => {
           }),
         } as Response
       }
+      if (url.includes("/jst_connectors/")) {
+        return {
+          json: async () => ({
+            jst_connectors: [
+              {
+                lcsc: "398543",
+                reference_series: "PH",
+                attributes: '{"Holes Structure":"1x2P"}',
+              },
+              {
+                lcsc: "495675",
+                reference_series: "PA",
+                attributes: '{"Pins Structure":"1x2P"}',
+              },
+              {
+                lcsc: "131337",
+                reference_series: "PH",
+                attributes: '{"Pins Structure":"1x2P"}',
+              },
+              {
+                lcsc: "173752",
+                reference_series: "PH",
+                attributes: { "Pins Structure": "1x2P" },
+              },
+            ],
+          }),
+        } as Response
+      }
       return {} as Response
     }) as unknown as typeof fetch
   })
@@ -498,6 +526,47 @@ describe("jlcPartsEngine", () => {
     expect(result).toEqual({
       jlcpcb: ["C165948", "C165949", "C165950"],
     })
+  })
+
+  test("should find PCB-mount JST connector parts by family and pin count", async () => {
+    const connector: AnySourceComponent = {
+      type: "source_component",
+      ftype: "simple_connector",
+      standard: "jst_ph",
+      pin_count: 2,
+      source_component_id: "source_component_0",
+      name: "J2",
+    }
+
+    const result = await jlcPartsEngine.findPart({
+      sourceComponent: connector,
+    })
+
+    expect(result).toEqual({
+      jlcpcb: ["C131337", "C173752"],
+    })
+
+    const connectorUrl = getFirstFetchedUrl(fetchedUrls)
+    expect(connectorUrl.pathname).toBe("/jst_connectors/list")
+    expect(connectorUrl.searchParams.get("pitch_mm")).toBe("2")
+    expect(connectorUrl.searchParams.get("num_pins")).toBe("2")
+  })
+
+  test("should skip JST searches without a pin count", async () => {
+    const connector: AnySourceComponent = {
+      type: "source_component",
+      ftype: "simple_connector",
+      standard: "jst_ph",
+      source_component_id: "source_component_0",
+      name: "J3",
+    }
+
+    const result = await jlcPartsEngine.findPart({
+      sourceComponent: connector,
+    })
+
+    expect(result).toEqual({})
+    expect(fetchedUrls).toHaveLength(0)
   })
 
   test("should return empty object for unknown component types", async () => {


### PR DESCRIPTION
## Summary

- add JLC part lookup for `jst_sh`, `jst_gh`, `jst_zh`, `jst_ph`, `jst_xh`, and `jst_vh`
- map each standard to its pitch and compatible JLC catalog reference series
- filter out wire housings and retain PCB-mount connectors before applying normal basic-part preference
- update `@tscircuit/props` and `circuit-json` so the new connector standards and `pin_count` are typed

## Why

`<connector standard="jst_ph" pinCount={2} />` currently receives no supplier part from the parts engine, so core has no footprint or CAD model to render. A raw JST catalog lookup also ranks cable housings such as `PHR-2-*` ahead of board headers. This change selects the board-mount `C131337` first for the 2-pin PH case.

JST-SH board headers are cataloged under the mating `SR/SZ` reference series, so that compatibility alias is included explicitly.

## Test plan

- `bun test`
- `bun run build`
- `bun run format:check`
- live integration check against jlcsearch and EasyEDA for a 2-pin connector in every supported JST family; every first candidate returned pads and an OBJ/STEP CAD model